### PR TITLE
Configurable Input App ID + Play Video

### DIFF
--- a/app.go
+++ b/app.go
@@ -4,7 +4,7 @@ package roku
 // https://github.com/kinghrothgar/roku/blob/master/roku/roku.go#L63
 type App struct {
 	Name    string `xml:",chardata" json:"name,omitempty"`
-	ID      int    `xml:"id,attr" json:"id,omitempty"`
+	ID      string `xml:"id,attr" json:"id,omitempty"`
 	Type    string `xml:"type,attr" json:"type,omitempty"`
 	SubType string `xml:"subtype,attr" json:"sub_type,omitempty"`
 	Version string `xml:"version,attr" json:"version,omitempty"`

--- a/apps.go
+++ b/apps.go
@@ -10,21 +10,21 @@ type Apps = []*App
 // Found using https://channelstore.roku.com/browse
 var (
 	// YouTubeAppID is the channel app ID number for Google's YouTube
-	YouTubeAppID = 837
+	YouTubeAppID = "837"
 	// NetflixAppID is the channel app ID number for Netflix
-	NetflixAppID = 12
+	NetflixAppID = "12"
 	// PrimeVideoAppID is the channel app ID number for Amazon Prime Video
-	PrimeVideoAppID = 13
+	PrimeVideoAppID = "13"
 	// FireFoxAppID is the channel app ID number for FireFox
-	FireFoxAppID = 47545
+	FireFoxAppID = "47545"
 	// HuluAppID is the channel app ID number for Hulu
-	HuluAppID = 2285
+	HuluAppID = "2285"
 	// PandoraAppID is the channel app ID number for Pandora
-	PandoraAppID = 28
+	PandoraAppID = "28"
 	// SpotifyAppID is the channel app ID number for Spotify
-	SpotifyAppID = 19977
+	SpotifyAppID = "19977"
 	// ESPNAppID is the channel app ID number for ESPN
-	ESPNAppID = 34376
+	ESPNAppID = "34376"
 	// PlayOnRokuID is the channel app ID number for PlayOnRoku
-	PlayOnRokuID = 15985
+	PlayOnRokuID = "15985"
 )

--- a/apps.go
+++ b/apps.go
@@ -25,4 +25,6 @@ var (
 	SpotifyAppID = 19977
 	// ESPNAppID is the channel app ID number for ESPN
 	ESPNAppID = 34376
+	// PlayOnRokuID is the channel app ID number for PlayOnRoku
+	PlayOnRokuID = 15985
 )

--- a/endpoint.go
+++ b/endpoint.go
@@ -16,7 +16,7 @@ type Endpoint struct {
 
 // InputOptions holds optional values for the "Input" method.
 type InputOptions struct {
-	AppID int
+	AppID string
 }
 
 func (e *Endpoint) String() string {
@@ -48,7 +48,7 @@ var (
 )
 
 // IsInstalledApp checks if the device has a given application ID
-func (e *Endpoint) IsInstalledApp(appID int) (bool, error) {
+func (e *Endpoint) IsInstalledApp(appID string) (bool, error) {
 	apps, err := e.Apps()
 	if err != nil {
 		return false, err
@@ -181,8 +181,8 @@ func (e *Endpoint) KeyDown(key string) error {
 }
 
 // Icon returns the image (PNG) for the given applicaton ID.
-func (e *Endpoint) Icon(id int) ([]byte, error) {
-	resp, err := http.Get(e.url + pathToQueryIcon + string(id))
+func (e *Endpoint) Icon(id string) ([]byte, error) {
+	resp, err := http.Get(e.url + pathToQueryIcon + id)
 
 	if err != nil {
 		return nil, err
@@ -202,8 +202,8 @@ func (e *Endpoint) Icon(id int) ([]byte, error) {
 }
 
 // LaunchApp starts an application on the roku device.
-func (e *Endpoint) LaunchApp(id int, params map[string]string) error {
-	u, err := url.Parse(e.url + pathToLaunch + string(id))
+func (e *Endpoint) LaunchApp(id string, params map[string]string) error {
+	u, err := url.Parse(e.url + pathToLaunch + id)
 	if err != nil {
 		return err
 	}

--- a/endpoint.go
+++ b/endpoint.go
@@ -83,6 +83,14 @@ func (e *Endpoint) Apps() (Apps, error) {
 		return nil, err
 	}
 
+	deviceInfo, err := e.DeviceInfo()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to determine whether PlayOnRoku installed: %w", err)
+	}
+	if deviceInfo.HasPlayOnRoku == "true" {
+		apps.All = append(apps.All, &App{Name: "Play On Roku", ID: PlayOnRokuID})
+	}
+
 	if len(apps.All) == 0 {
 		return nil, ErrNoAppsFound
 	}
@@ -275,6 +283,20 @@ func (e *Endpoint) Search(params map[string]string) error {
 	}
 
 	return nil
+}
+
+// PlayVideo wraps Input for the Play On Roku app. to play a custom video.
+func (e *Endpoint) PlayVideo(uri string) error {
+	if _, err := url.Parse(uri); err != nil {
+		return err
+	}
+
+	params := map[string]string{
+		"t": "v", // Indicates a video type.
+		"u": uri,
+	}
+
+	return e.Input(params, &InputOptions{AppID: PlayOnRokuID})
 }
 
 // Input provides input functionality for a roku device.

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -194,7 +194,7 @@ func TestInput(t *testing.T) {
 		"acceleration.x": "0.0",
 		"acceleration.y": "0.0",
 		"acceleration.z": "9.8",
-	})
+	}, nil)
 
 	if err != nil {
 		t.Error(err)

--- a/endpoint_test.go
+++ b/endpoint_test.go
@@ -1,6 +1,9 @@
 package roku
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestActiveApp(t *testing.T) {
 	devices, err := Find(DefaultWaitTime)
@@ -198,6 +201,61 @@ func TestInput(t *testing.T) {
 
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestPlayVideo(t *testing.T) {
+	devices, err := Find(DefaultWaitTime)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(devices) == 0 {
+		t.Fatal("no roku devices found")
+	}
+
+	endpoint := devices[0]
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This does not block on a successful start. Fake URL, so the test should pass,
+	// though the video itself will not load.
+	err = endpoint.PlayVideo("https://fake.url/fake.mp4")
+	if err != nil {
+		t.Fatalf("Failed to play video: %v", err)
+	}
+}
+
+func TestInputBadApp(t *testing.T) {
+	devices, err := Find(DefaultWaitTime)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(devices) == 0 {
+		t.Fatal("no roku devices found")
+	}
+
+	endpoint := devices[0]
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	badInputOptions := &InputOptions{
+		AppID: "FAKE",
+	}
+
+	err = endpoint.Input(Params{
+		"junk": "data",
+	}, badInputOptions)
+
+	if !errors.Is(err, ErrAppNotFound) {
+		t.Fatalf("Expected app not found error")
 	}
 }
 


### PR DESCRIPTION
### What?

This extends the `Input` method of the `Endpoint` `struct` to accept an optional configuration struct (`InputOptions`).
* The configuration struct currently has a single member, `AppID`.
* If the struct is not `nil` and `AppID` is not default, the client will attempt to send the input data to the specified app.

And further wrapping this new `Input` is a `PlayVideo` method, which takes a video URL. This URL is sent to the **Play On Roku** application, which should already be installed on any relatively modern Roku device, at least since Roku 2.

I also fixed what appears to be a bug, depending on the model of Roku you're using. As mine is a TV, I have apps. w/ non-integer IDs (ex. `tvinput.hdmi1`), which was breaking the `Apps` method for me.

### Why?

First off, neat Go package!

I've used a handful of programs to play videos on my Roku and thought it would be fun to contribute this.

### How?

There is an app. called **Play on Roku** that comes on most Roku devices, which is more or less hidden; however, data can still be sent to it, and given a legitimate video URL it will play the video.

The [information captured here](https://github.com/pranav-prakash/RokuCast/issues/7) is what I used to learn about `/input`, as it applies to this particular app.

### Sample

```
package main

import (
        "fmt"
        "github.com/picatz/roku"
)

func main() {
        devices, _ := roku.Find(roku.DefaultWaitTime)

        for _, device := range devices {
                err := device.PlayVideo("https://link.to/some/video.mp4")
                fmt.Println(err)
        }
}
```

I've tested with a variety of video formats with my Roku TV, using videos from [here](https://test-videos.co.uk/).